### PR TITLE
feat: Add idempotent request-ssl-certificate helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Thumbs.db
 
 .omc/
 
+
+# Git worktrees
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -201,7 +201,19 @@ For developers: Run unit and integration tests to verify code functionality:
 
 ### 4. Request SSL Certificate (if needed)
 
-If you don't have an ACM certificate yet, you can request one:
+If you don't have an ACM certificate yet, the easiest path is the helper script. It is idempotent: if a certificate already exists for the domain it just prints the DNS validation records to add; if none exists it requests one (apex + `*.` wildcard, DNS validation) and then prints the records:
+
+```bash
+# Uses DOMAIN_NAME from config.env, or pass a domain explicitly
+./scripts/request-ssl-certificate.sh
+./scripts/request-ssl-certificate.sh example.com
+```
+
+The script prints a CNAME record (Name + Value) to add at your DNS provider. A certificate covering both `example.com` and `*.example.com` uses a single shared CNAME, so you only add one record. If your domain is hosted in Route 53, you can add it with [`./scripts/setup-route53-dns.sh`](#route-53-dns-management-script).
+
+#### Manual alternative
+
+You can also request the certificate directly:
 
 ```bash
 aws acm request-certificate \
@@ -210,6 +222,17 @@ aws acm request-certificate \
   --validation-method DNS \
   --region us-east-1
 ```
+
+This returns a certificate ARN but not the DNS records. Retrieve them with:
+
+```bash
+aws acm describe-certificate \
+  --certificate-arn YOUR_CERT_ARN \
+  --region us-east-1 \
+  --query "Certificate.DomainValidationOptions"
+```
+
+Then add the returned CNAME record at your DNS provider.
 
 **Note:** You don't need to wait for the certificate to be issued before running the setup script. The script will automatically detect if your certificate is pending validation, display the required DNS records, and give you options to:
 - Wait for validation (with automatic polling)
@@ -441,6 +464,7 @@ The scripts will **never** create duplicate resources:
 ├── scripts/
 │   ├── setup-s3-buckets.sh         # S3 bucket creation and configuration
 │   ├── setup-ssl-certificate.sh    # ACM certificate validation
+│   ├── request-ssl-certificate.sh  # Request ACM cert if missing and show DNS validation records
 │   ├── setup-iam-roles.sh          # IAM role and policy setup
 │   ├── create-eb-environment.sh    # EB environment creation
 │   ├── configure-ssl.sh            # Load balancer SSL configuration

--- a/scripts/request-ssl-certificate.sh
+++ b/scripts/request-ssl-certificate.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+# ACM Certificate Request Utility
+# Idempotently ensures an ACM certificate exists for a domain and prints the
+# DNS validation records that must be added to the domain's DNS provider.
+#
+#   - If a certificate already exists for the domain, its DNS validation
+#     records and status are displayed (no new certificate is requested).
+#   - If none exists, a new certificate is requested (apex + wildcard SAN,
+#     DNS validation) and its validation records are displayed.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Reuse shared config resolution and the certificate lookup/display helpers
+# (find_certificate_by_domain, get_certificate_status,
+# display_dns_validation_records, and the log_* helpers).
+source "$SCRIPT_DIR/load-infrastructure-config.sh"
+source "$SCRIPT_DIR/setup-ssl-certificate.sh"
+
+request_certificate() {
+    local domain=$1
+    local region=$2
+
+    log_info "Requesting ACM certificate for $domain (and *.$domain)..."
+
+    aws acm request-certificate \
+        --domain-name "$domain" \
+        --subject-alternative-names "*.$domain" \
+        --validation-method DNS \
+        --profile "$AWS_PROFILE" \
+        --region "$region" \
+        --query "CertificateArn" \
+        --output text
+}
+
+# Poll until ACM has populated the DNS validation records for a freshly
+# requested certificate (they are not always available immediately).
+wait_for_validation_records() {
+    local cert_arn=$1
+    local region=$2
+    local max_attempts=${3:-12}
+    local wait_interval=5
+
+    if [ "${TEST_MODE:-}" = "true" ]; then
+        return 0
+    fi
+
+    local attempt=0
+    while [ $attempt -lt $max_attempts ]; do
+        local record_name=$(aws acm describe-certificate \
+            --certificate-arn "$cert_arn" \
+            --profile "$AWS_PROFILE" \
+            --region "$region" \
+            --query "Certificate.DomainValidationOptions[0].ResourceRecord.Name" \
+            --output text)
+
+        if [ -n "$record_name" ] && [ "$record_name" != "None" ]; then
+            return 0
+        fi
+
+        attempt=$((attempt + 1))
+        sleep $wait_interval
+    done
+
+    log_warn "DNS validation records were not available yet; re-run this script in a moment to see them"
+    return 0
+}
+
+show_usage() {
+    cat <<EOF
+Usage: $0 [DOMAIN] [OPTIONS]
+
+Ensure an ACM certificate exists for a domain and print the DNS validation
+records to add at your DNS provider.
+
+  - If a certificate already exists for the domain, its validation records
+    and status are shown (no new certificate is requested).
+  - If none exists, a new certificate is requested and its validation
+    records are shown.
+
+Arguments:
+  DOMAIN              Domain to use (defaults to DOMAIN_NAME from config)
+
+Options:
+  --config FILE       Use a specific configuration file
+  --env NAME          Use config.NAME.env from the repo root
+  -h, --help          Show this help message
+
+Examples:
+
+  # Use DOMAIN_NAME from config.env
+  $0
+
+  # Request/show for an explicit domain
+  $0 example.com
+
+  # Use a named environment's config
+  $0 --env staging
+
+After adding the displayed CNAME record at your DNS provider, AWS validates
+the certificate (usually within 5-30 minutes). If your domain is hosted in
+Route 53, you can add the record with ./scripts/setup-route53-dns.sh. Once
+the certificate is ISSUED, run ./setup-eb-environment.sh.
+EOF
+}
+
+main() {
+    local domain=""
+    local cli_config=""
+    local cli_env=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --config)
+                cli_config="$2"
+                shift 2
+                ;;
+            --env)
+                cli_env="$2"
+                shift 2
+                ;;
+            -h|--help)
+                show_usage
+                return 0
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                show_usage
+                return 1
+                ;;
+            *)
+                domain="$1"
+                shift
+                ;;
+        esac
+    done
+
+    # Load configuration. Use strict loading when a file was explicitly named;
+    # otherwise load config.env if present but continue without it (so an
+    # explicit DOMAIN argument or a pre-set environment still works).
+    if [ -n "$cli_config" ] || [ -n "$cli_env" ]; then
+        if ! infrastructure_config_load "$REPO_ROOT" "$cli_config" "$cli_env"; then
+            return 1
+        fi
+    else
+        infrastructure_config_load_optional "$REPO_ROOT"
+    fi
+
+    AWS_PROFILE="${AWS_PROFILE:-default}"
+    AWS_REGION="${AWS_REGION:-us-east-1}"
+
+    if [ -z "$domain" ]; then
+        domain="${DOMAIN_NAME:-}"
+    fi
+
+    if [ -z "$domain" ]; then
+        log_error "No domain provided. Pass one as an argument or set DOMAIN_NAME in your config."
+        show_usage
+        return 1
+    fi
+
+    local cert_arn=$(find_certificate_by_domain "$domain" "$AWS_REGION")
+
+    if [ -n "$cert_arn" ] && [ "$cert_arn" != "None" ]; then
+        log_info "Found existing certificate: $cert_arn"
+        display_dns_validation_records "$cert_arn" "$AWS_REGION"
+        local status=$(get_certificate_status "$cert_arn" "$AWS_REGION")
+        log_info "Certificate status: $status"
+        if [ "$status" = "ISSUED" ]; then
+            log_info "Certificate is already issued — no DNS action needed."
+        fi
+    else
+        log_info "No certificate found for $domain — requesting a new one..."
+        cert_arn=$(request_certificate "$domain" "$AWS_REGION")
+        log_info "Certificate requested: $cert_arn"
+        wait_for_validation_records "$cert_arn" "$AWS_REGION"
+        display_dns_validation_records "$cert_arn" "$AWS_REGION"
+    fi
+
+    echo ""
+    log_info "Add the CNAME record above at your DNS provider."
+    log_info "If your domain is in Route 53, you can use ./scripts/setup-route53-dns.sh"
+    log_info "Once the certificate is ISSUED, run ./setup-eb-environment.sh"
+
+    return 0
+}
+
+# Run main function if script is executed directly
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main "$@"
+fi

--- a/tests/aws-mock.bash
+++ b/tests/aws-mock.bash
@@ -589,6 +589,14 @@ CONFIGJSON
                 echo '{"CertificateSummaryList": [{"DomainName": "example.com", "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"}]}'
             fi
             ;;
+        acm.request-certificate)
+            local new_arn="arn:aws:acm:us-east-1:123456789012:certificate/new-00000000-0000-0000-0000-000000000000"
+            if [[ "$all_args" == *"CertificateArn"* ]] && [[ "$all_args" == *"--output text"* ]]; then
+                echo "$new_arn"
+            else
+                echo '{"CertificateArn": "'"$new_arn"'"}'
+            fi
+            ;;
         acm.describe-certificate)
             local query=$(get_arg_value "--query" "$all_args")
             local mock_status="${MOCK_ACM_CERT_STATUS:-ISSUED}"

--- a/tests/unit/request-ssl-certificate.bats
+++ b/tests/unit/request-ssl-certificate.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load '../test_helper'
+load '../aws-mock'
+
+setup() {
+    setup_test_env
+    source "$SCRIPT_DIR/scripts/request-ssl-certificate.sh"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+@test "request_certificate returns an ACM certificate ARN" {
+    run request_certificate "newdomain.com" "us-east-1"
+    [ "$status" -eq 0 ]
+    assert_output --partial "arn:aws:acm"
+}
+
+@test "wait_for_validation_records skips in test mode" {
+    run wait_for_validation_records "arn:aws:acm:us-east-1:123456789012:certificate/test" "us-east-1"
+    [ "$status" -eq 0 ]
+}
+
+@test "main reuses existing certificate and shows DNS records" {
+    export DOMAIN_NAME="example.com"
+    run main
+    [ "$status" -eq 0 ]
+    assert_output --partial "Found existing certificate"
+    assert_output --partial "DNS Validation Records"
+    # Must not request a new certificate when one already exists
+    refute_output --partial "requesting a new"
+}
+
+@test "main requests a new certificate when none exists" {
+    export DOMAIN_NAME="newdomain.com"
+    run main
+    [ "$status" -eq 0 ]
+    assert_output --partial "requesting a new"
+    assert_output --partial "DNS Validation Records"
+}
+
+@test "main accepts a positional domain argument" {
+    unset DOMAIN_NAME
+    run main "example.com"
+    [ "$status" -eq 0 ]
+    assert_output --partial "Found existing certificate"
+}
+
+@test "show_usage displays help text" {
+    run show_usage
+    [ "$status" -eq 0 ]
+    assert_output --partial "Usage:"
+}
+
+@test "main --help displays usage" {
+    run main --help
+    [ "$status" -eq 0 ]
+    assert_output --partial "Usage:"
+}


### PR DESCRIPTION
## Summary
Adds `scripts/request-ssl-certificate.sh`, a small standalone helper that ensures an ACM certificate exists for a domain and prints the DNS validation records to add at the DNS provider.

- **If a certificate already exists** for the domain → prints its DNS validation records and status (no new request — idempotent).
- **If none exists** → requests one (apex + `*.` wildcard SAN, DNS validation), then prints the records.

This closes a gap in the README's step 4: it told users to run `aws acm request-certificate` but never showed how to retrieve the DNS validation records afterward.

## Implementation notes
- Reuses the existing helpers in `setup-ssl-certificate.sh` (`find_certificate_by_domain`, `get_certificate_status`, `display_dns_validation_records`) instead of duplicating lookup/display logic. The only genuinely new piece is actually running `aws acm request-certificate` (the existing code only printed instructions).
- Follows the standalone-utility structure of `setup-route53-dns.sh`; config is loaded via the shared `load-infrastructure-config.sh` (optional load so an explicit domain arg / preset env works without a config file).

## Docs
- README step 4 now leads with the helper script and documents the manual `describe-certificate` retrieval as an alternative.
- Added the script to the Project Structure list.

## Testing
- New `tests/unit/request-ssl-certificate.bats` (7 tests), plus an `acm.request-certificate` mock in `tests/aws-mock.bash`.
- Full unit suite: **249 passing, 0 failures** (242 baseline + 7 new).
- Manual read-only check against real AWS confirmed it finds an existing cert, shows the correct CNAME, and does not request a duplicate.

Note: includes a small `.gitignore` change adding `.worktrees/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)